### PR TITLE
fix: replace hardcoded domain URLs with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 # Site URL for metadata, sitemaps, and structured data
-# Override this for different environments (local dev, Vercel previews, etc.)
+# SITE_URL is server-only (preferred for robots.ts, sitemap.ts, etc.)
+# NEXT_PUBLIC_SITE_URL is accessible on the client side as well
+# If both are set, SITE_URL takes precedence
+# Defaults to http://localhost:3000 when not set
+
+# Server-only site URL (recommended for production)
+SITE_URL=https://www.lumonipsum.com
+
+# Public site URL (also accessible in client components)
 NEXT_PUBLIC_SITE_URL=https://www.lumonipsum.com

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ const vt323 = VT323({
   variable: "--font-vt323",
 });
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.lumonipsum.com';
+const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 export const metadata: Metadata = {
   title: "Lumon Ipsum Generator | Severance-themed Lorem Ipsum Text",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from 'next'
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.lumonipsum.com';
+const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from 'next'
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.lumonipsum.com';
+const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/app/structured-data.tsx
+++ b/app/structured-data.tsx
@@ -1,6 +1,6 @@
 import Script from 'next/script';
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.lumonipsum.com';
+const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 interface StructuredDataProps {
   url?: string;


### PR DESCRIPTION
Closes lumon-7bt. Replaces hardcoded URLs in robots.ts, sitemap.ts, layout.tsx, and structured-data.tsx with SITE_URL/NEXT_PUBLIC_SITE_URL env vars. Adds .env.example for documentation. Falls back to localhost:3000 instead of production URL for safer local dev.