### PR TITLE
Remove unused Google Fonts (Geist, Geist_Mono, IBM_Plex_Mono)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,26 +1,9 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import { IBM_Plex_Mono, VT323 } from "next/font/google";
+import { VT323 } from "next/font/google";
 import "./globals.css";
 import StructuredData from "./structured-data";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-const ibmPlexMono = IBM_Plex_Mono({
-  subsets: ["latin"],
-  weight: ["400", "500", "600"],
-  variable: "--font-ibm-plex-mono",
-});
 
 const vt323 = VT323({
   subsets: ["latin"],
@@ -98,7 +81,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-title" content="Lumon Ipsum" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${ibmPlexMono.variable} ${vt323.variable} antialiased`}
+        className={`${vt323.variable} antialiased`}
       >
         <StructuredData />
         {children}


### PR DESCRIPTION
## Summary

Removes 3 unused Google Font imports from `app/layout.tsx`:

- **Geist** (`--font-geist-sans`) — not referenced anywhere in the app
- **Geist_Mono** (`--font-geist-mono`) — not referenced anywhere in the app
- **IBM_Plex_Mono** (`--font-ibm-plex-mono`) — not referenced anywhere in the app

Only **VT323** (`--font-vt323`) is actually used (referenced in `globals.css`), so it remains.

## Impact

- **~45-150KB font payload savings** (3 fewer font families to download)
- **Faster LCP** (fewer blocking resources on initial load)
- No visual or functional changes — VT323 is the only font in use

## Verification

- [x] `npm run build` passes
- [x] `npm run lint` passes (pre-existing warnings only)
- [x] No references to removed font variables exist outside `layout.tsx`

Resolves lumonipsum-ap2