### PR TITLE
Refactor MDR animation to useReducer

### DIFF
--- a/hooks/use-mdr-animation.ts
+++ b/hooks/use-mdr-animation.ts
@@ -1,10 +1,23 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useReducer } from 'react';
 import type { Position } from '@/types';
 
 const NUM_ROWS = 11;
 const MAX_OFFSET = 5.5;
 const UPDATE_INTERVAL = 1500;
 const BASE_CHAR_WIDTH = 22;
+
+type State = {
+  charsPerRow: number;
+  rows: string[];
+  opacities: number[][];
+  positions: Position[][];
+  initialized: boolean;
+};
+
+type Action =
+  | { type: 'init'; charsPerRow: number }
+  | { type: 'tick' }
+  | { type: 'resize'; charsPerRow: number };
 
 const generateRandomRow = (length: number) => {
   let row = '';
@@ -21,83 +34,153 @@ const calculateColumns = () => {
   return Math.max(10, Math.min(35, columns - 1));
 };
 
+const createInitialState = (charsPerRow: number): State => ({
+  charsPerRow,
+  rows: Array(NUM_ROWS)
+    .fill(0)
+    .map(() => generateRandomRow(charsPerRow)),
+  opacities: Array(NUM_ROWS)
+    .fill(0)
+    .map(() =>
+      Array(charsPerRow)
+        .fill(0)
+        .map(() => Math.random() * 0.2 + 0.8)
+    ),
+  positions: Array(NUM_ROWS)
+    .fill(0)
+    .map(() =>
+      Array(charsPerRow)
+        .fill(0)
+        .map(() => ({
+          x: (Math.random() * 2 - 1) * MAX_OFFSET,
+          y: (Math.random() * 2 - 1) * MAX_OFFSET,
+        }))
+    ),
+  initialized: false,
+});
+
+const resizeState = (prev: State, newCharsPerRow: number): State => {
+  if (newCharsPerRow === prev.charsPerRow) return prev;
+
+  const rows: string[] = [];
+  const opacities: number[][] = [];
+  const positions: Position[][] = [];
+
+  for (let r = 0; r < NUM_ROWS; r++) {
+    const oldRow = prev.rows[r] ?? '';
+    const oldOpac = prev.opacities[r] ?? [];
+    const oldPos = prev.positions[r] ?? [];
+
+    let newRow: string;
+    let newOpac: number[];
+    let newPos: Position[];
+
+    if (newCharsPerRow > oldRow.length) {
+      const extraChars = generateRandomRow(newCharsPerRow - oldRow.length);
+      newRow = oldRow + extraChars;
+      newOpac = [
+        ...oldOpac,
+        ...Array(newCharsPerRow - oldOpac.length)
+          .fill(0)
+          .map(() => Math.random() * 0.2 + 0.8),
+      ];
+      newPos = [
+        ...oldPos,
+        ...Array(newCharsPerRow - oldPos.length)
+          .fill(0)
+          .map(() => ({
+            x: (Math.random() * 2 - 1) * MAX_OFFSET,
+            y: (Math.random() * 2 - 1) * MAX_OFFSET,
+          })),
+      ];
+    } else {
+      newRow = oldRow.slice(0, newCharsPerRow);
+      newOpac = oldOpac.slice(0, newCharsPerRow);
+      newPos = oldPos.slice(0, newCharsPerRow);
+    }
+
+    rows.push(newRow);
+    opacities.push(newOpac);
+    positions.push(newPos);
+  }
+
+  return { ...prev, charsPerRow: newCharsPerRow, rows, opacities, positions };
+};
+
+const applyTick = (prev: State): State => {
+  const newOpacities = prev.opacities.map((row) => [...row]);
+  const newPositions = prev.positions.map((row) => row.map((p) => ({ ...p })));
+
+  for (let i = 0; i < 5; i++) {
+    const row = Math.floor(Math.random() * NUM_ROWS);
+    const col = Math.floor(Math.random() * prev.charsPerRow);
+    if (newOpacities[row] && newOpacities[row][col] !== undefined) {
+      newOpacities[row][col] = Math.random() * 0.2 + 0.8;
+    }
+  }
+
+  for (let i = 0; i < 8; i++) {
+    const row = Math.floor(Math.random() * NUM_ROWS);
+    const col = Math.floor(Math.random() * prev.charsPerRow);
+    if (newPositions[row] && newPositions[row][col]) {
+      newPositions[row][col] = {
+        x: (Math.random() * 2 - 1) * MAX_OFFSET,
+        y: (Math.random() * 2 - 1) * MAX_OFFSET,
+      };
+    }
+  }
+
+  return { ...prev, opacities: newOpacities, positions: newPositions };
+};
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'init': {
+      if (action.charsPerRow === state.charsPerRow) {
+        return { ...state, initialized: true };
+      }
+      return { ...createInitialState(action.charsPerRow), initialized: true };
+    }
+    case 'tick':
+      return applyTick(state);
+    case 'resize':
+      return resizeState(state, action.charsPerRow);
+    default:
+      return state;
+  }
+};
+
 export const useMdrAnimation = () => {
-  const [charsPerRow, setCharsPerRow] = useState(calculateColumns);
-  const [rows, setRows] = useState<string[]>([]);
-  const [opacities, setOpacities] = useState<number[][]>([]);
-  const [positions, setPositions] = useState<Position[][]>([]);
-  const initialized = useRef(false);
+  const [state, dispatch] = useReducer(reducer, undefined, () =>
+    createInitialState(calculateColumns())
+  );
 
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect -- client-only initialization:
        random values cannot be computed during SSR (hydration mismatch),
        and column count depends on window.innerWidth (not available server-side) */
-    setRows(Array(NUM_ROWS).fill(0).map(() => generateRandomRow(charsPerRow)));
-    setOpacities(
-      Array(NUM_ROWS).fill(0).map(() =>
-        Array(charsPerRow).fill(0).map(() => Math.random() * 0.2 + 0.8)
-      )
-    );
-    setPositions(
-      Array(NUM_ROWS).fill(0).map(() =>
-        Array(charsPerRow).fill(0).map(() => ({
-          x: (Math.random() * 2 - 1) * MAX_OFFSET,
-          y: (Math.random() * 2 - 1) * MAX_OFFSET,
-        }))
-      )
-    );
+    dispatch({ type: 'init', charsPerRow: calculateColumns() });
     /* eslint-enable react-hooks/set-state-in-effect */
-    if (!initialized.current) {
-      initialized.current = true;
-    }
-  }, [charsPerRow]);
+  }, []);
 
   useEffect(() => {
     const handleResize = () => {
-      setCharsPerRow(calculateColumns());
+      dispatch({ type: 'resize', charsPerRow: calculateColumns() });
     };
 
-    if (!initialized.current) {
-      handleResize();
-    }
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   useEffect(() => {
-    if (!initialized.current) return;
+    if (!state.initialized) return;
 
     const interval = setInterval(() => {
-      setOpacities(prev => {
-        const newOpacities = [...prev];
-        for (let i = 0; i < 5; i++) {
-          const row = Math.floor(Math.random() * NUM_ROWS);
-          const col = Math.floor(Math.random() * charsPerRow);
-          if (newOpacities[row] && newOpacities[row][col] !== undefined) {
-            newOpacities[row][col] = Math.random() * 0.2 + 0.8;
-          }
-        }
-        return newOpacities;
-      });
-
-      setPositions(prev => {
-        const newPositions = [...prev];
-        for (let i = 0; i < 8; i++) {
-          const row = Math.floor(Math.random() * NUM_ROWS);
-          const col = Math.floor(Math.random() * charsPerRow);
-          if (newPositions[row] && newPositions[row][col]) {
-            newPositions[row][col] = {
-              x: (Math.random() * 2 - 1) * MAX_OFFSET,
-              y: (Math.random() * 2 - 1) * MAX_OFFSET,
-            };
-          }
-        }
-        return newPositions;
-      });
+      dispatch({ type: 'tick' });
     }, UPDATE_INTERVAL);
 
     return () => clearInterval(interval);
-  }, [charsPerRow]);
+  }, [state.initialized]);
 
-  return { rows, opacities, positions };
+  return { rows: state.rows, opacities: state.opacities, positions: state.positions };
 };


### PR DESCRIPTION
Closes lumonipsum-0jz. Merges rows/opacities/positions into a single useReducer to batch updates and prevent re-render thrashing. Separates interval ticks from resize re-initialization to avoid flash on window resize.