### PR TITLE
refactor: extract config, standardize colors, harden security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 # Test output (should not be committed)
 test-results/
+playwright-report/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,14 +4,13 @@ import "./globals.css";
 import StructuredData from "./structured-data";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { siteUrl } from "@/lib/config";
 
 const vt323 = VT323({
   subsets: ["latin"],
   weight: ["400"],
   variable: "--font-vt323",
 });
-
-const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 export const metadata: Metadata = {
   title: "Lumon Ipsum Generator | Severance-themed Lorem Ipsum Text",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,14 +106,14 @@ export default function Home() {
   };
 
   return (
-    <main className="min-h-screen p-4 sm:p-8 flex items-center justify-center bg-[#0e1a26]">
+    <main className="min-h-screen p-4 sm:p-8 flex items-center justify-center bg-[var(--archive)]">
       <div className="w-full max-w-4xl">
         <TerminalScreen>
           <div className="text-center space-y-2 mb-12">
             <div className="flex items-center justify-center space-x-2">
-              <div className="h-2 w-2 rounded-full bg-[#afcbd6] animate-pulse"></div>
-              <h1 className="text-2xl font-mono tracking-wide">LUMON IPSUM GENERATOR</h1>
-              <div className="h-2 w-2 rounded-full bg-[#afcbd6] animate-pulse"></div>
+              <div className="h-2 w-2 rounded-full bg-[var(--protocol)] animate-pulse"></div>
+              <h1 className="text-2xl tracking-wide">LUMON IPSUM GENERATOR</h1>
+              <div className="h-2 w-2 rounded-full bg-[var(--protocol)] animate-pulse"></div>
             </div>
             <p className="text-sm opacity-80">PROTOCOL.GENERATE.TEXT</p>
           </div>
@@ -194,7 +194,7 @@ export default function Home() {
               </div>
               <div className="space-y-4">
                 {generatedText.map((paragraph, index) => (
-                  <p key={index} className="text-[#f3ffff]">{paragraph}</p>
+                  <p key={index} className="text-[var(--clarity)]">{paragraph}</p>
                 ))}
               </div>
             </GeneratedText>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,13 +1,11 @@
 import { MetadataRoute } from 'next'
-
-const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+import { siteUrl } from '@/lib/config';
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: '/private/',
     },
     sitemap: `${siteUrl}/sitemap.xml`,
   }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,5 @@
 import { MetadataRoute } from 'next'
-
-const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+import { siteUrl } from '@/lib/config';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/app/structured-data.tsx
+++ b/app/structured-data.tsx
@@ -1,10 +1,6 @@
 import Script from 'next/script';
-
-const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-
-interface StructuredDataProps {
-  url?: string;
-}
+import { siteUrl } from '@/lib/config';
+import { StructuredDataProps } from '@/types';
 
 export default function StructuredData({ url = siteUrl }: StructuredDataProps) {
   const websiteSchema = {
@@ -99,6 +95,9 @@ export default function StructuredData({ url = siteUrl }: StructuredDataProps) {
 
   return (
     <>
+      {/* dangerouslySetInnerHTML is used here because Next.js Script does not support
+          a children/content prop for JSON-LD. Each script has a unique id to ensure
+          stable rendering across re-renders. */}
       <Script
         id="website-schema"
         type="application/ld+json"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,8 @@ const eslintConfig = defineConfig([
     "build",
     "dist",
     "coverage",
+    "playwright-report",
+    "test-results",
     ".env*",
     "next-env.d.ts",
   ]),

--- a/features/mdr-numbers.test.tsx
+++ b/features/mdr-numbers.test.tsx
@@ -30,7 +30,7 @@ describe('MDRNumbers', () => {
 
     const container = document.querySelector('.generated-text');
     expect(container).toBeInTheDocument();
-    expect(container).toHaveClass('generated-text', 'font-mono');
+    expect(container).toHaveClass('generated-text');
 
     // Check that numbers are rendered
     expect(screen.getByText('1')).toBeInTheDocument();
@@ -49,14 +49,14 @@ describe('MDRNumbers', () => {
     render(<MDRNumbers className="custom-class" />);
 
     const container = document.querySelector('.generated-text');
-    expect(container).toHaveClass('generated-text', 'font-mono', 'custom-class');
+    expect(container).toHaveClass('generated-text', 'custom-class');
   });
 
   it('renders with default className when none provided', () => {
     render(<MDRNumbers />);
 
     const container = document.querySelector('.generated-text');
-    expect(container).toHaveClass('generated-text', 'font-mono');
+    expect(container).toHaveClass('generated-text');
   });
 
   it('renders spans with correct styles', () => {

--- a/features/mdr-numbers.tsx
+++ b/features/mdr-numbers.tsx
@@ -5,7 +5,7 @@ export default function MDRNumbers({ className = '' }: MDRNumbersProps) {
   const { rows, opacities, positions } = useMdrAnimation();
 
   return (
-    <div className={`generated-text font-mono ${className}`}>
+    <div className={`generated-text ${className}`}>
       <div className="p-4 w-full">
         {rows.map((row, i) => (
           <div

--- a/hooks/use-mdr-animation.ts
+++ b/hooks/use-mdr-animation.ts
@@ -1,3 +1,7 @@
+/**
+ * useMdrAnimation hook
+ * Manages the MDR numbers animation state including rows, opacities, and positions.
+ */
 import { useEffect, useReducer } from 'react';
 import type { Position } from '@/types';
 
@@ -156,11 +160,10 @@ export const useMdrAnimation = () => {
   );
 
   useEffect(() => {
-    /* eslint-disable react-hooks/set-state-in-effect -- client-only initialization:
+    /* client-only initialization:
        random values cannot be computed during SSR (hydration mismatch),
        and column count depends on window.innerWidth (not available server-side) */
     dispatch({ type: 'init', charsPerRow: calculateColumns() });
-    /* eslint-enable react-hooks/set-state-in-effect */
   }, []);
 
   useEffect(() => {

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -1,0 +1,8 @@
+import { siteUrl } from './config';
+
+describe('config', () => {
+  it('exports siteUrl as a non-empty string', () => {
+    expect(typeof siteUrl).toBe('string');
+    expect(siteUrl.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,1 @@
+export const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,11 @@ const nextConfig: NextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com;",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-insights.com;",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), autoplay=(), payment=(), usb=(), magnetometer=(), gyroscope=(), browsing-topics=()",
           },
         ],
       },

--- a/seed.spec.ts
+++ b/seed.spec.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test.describe('Test group', () => {
-  test('seed', async ({ page }) => {
-    // generate code here.
-  });
-});

--- a/tests/visual/responsive.spec.ts
+++ b/tests/visual/responsive.spec.ts
@@ -4,9 +4,10 @@ test.describe('Visual Tests', () => {
   test('Terminal Aesthetic', async ({ page }) => {
     await page.goto('http://localhost:3000');
     
-    // Verify dark background
+    // Verify main element is visible and uses the archive background class
     const mainElement = page.locator('main');
-    await expect(mainElement).toHaveClass(/bg-\[#0e1a26\]/);
+    await expect(mainElement).toBeVisible();
+    await expect(mainElement).toHaveClass(/bg-\[var\(--archive\)\]/);
     
     // Verify terminal screen is present
     await expect(page.locator('[class*="terminal"]')).toBeVisible().catch(() => {


### PR DESCRIPTION
## Summary
Closes #lumonipsum-rvk, #lumonipsum-1f3, #lumonipsum-2p2

### Changes
- **lumonipsum-rvk**: Extract shared `siteUrl` config into `lib/config.ts`; replace 4 duplicated definitions with imports.
- **lumonipsum-1f3**: Standardize hardcoded Tailwind colors to CSS variable references; remove redundant `font-mono` classes; remove duplicate `StructuredDataProps` interface; update tests.
- **lumonipsum-2p2**: Add `Permissions-Policy` header; remove `/private/` from robots; remove `unsafe-eval` from CSP; add `playwright-report`/`test-results` to ESLint ignores; remove stale `seed.spec.ts`.

### Quality gates
- [x] `npm run build`
- [x] `npm run lint` (0 errors)
- [x] `npm test` (10 suites / 61 tests passed)
- [x] `npx playwright test --project='chromium'` (38/38 passed)
- [x] `npx playwright test --project='chromium' --project='firefox' --project='webkit' tests/core/initial-render.spec.ts tests/compatibility/basic.spec.ts` (6/6 passed)

---
**Do not merge** — awaiting review.